### PR TITLE
format yml for tls compatibility

### DIFF
--- a/docs/configuration/gateway.config.yml/https.md
+++ b/docs/configuration/gateway.config.yml/https.md
@@ -16,13 +16,13 @@ The https section is used to configure HTTPS. Express Gateway will listen on the
 https:
   port: 9443
   tls:
-    - "*.demo.io":
+    "*.demo.io":
         key: example/keys/demo.io.key.pem
         cert: example/keys/demo.io.cert.pem
-    - "api.acme.com":
+    "api.acme.com":
         key: example/keys/acme.com.key.pem
         cert: example/keys/acme.com.cert.pem
-    - "default":
+    "default":
         key: example/keys/eg.io.key.pem
         cert: example/keys/eg.io.cert.pem
 


### PR DESCRIPTION
Based on an issue identified with how express-gateway parses the tls configuration for https, removing the dashes while maintaining the formatting formats the final json object to be compatible with existing tests and code. 

See [issue #367](https://github.com/ExpressGateway/express-gateway/issues/367) for a detailed description of the issue that this change address.

