### PR TITLE
doc/fix link and formatting

### DIFF
--- a/_posts/2017-08-31-getting-started-with-oauth2.md
+++ b/_posts/2017-08-31-getting-started-with-oauth2.md
@@ -78,7 +78,7 @@ pipelines:
               changeOrigin: true
 ```
 
-Once you turn on OAuth2, you should see an 'Unauthorized' error when you visit [http://localhost:3000/ip](http://localhost:3000/ip). You need to restart the server for config changes to take effect, so if you ran npm start be sure to kill the process and then re-run `npm start`.
+Once you turn on OAuth2, you should see an 'Unauthorized' error when you visit [http://localhost:8080/ip](http://localhost:8080/ip). You need to restart the server for config changes to take effect, so if you ran npm start be sure to kill the process and then re-run `npm start`.
 The next step is to create a new Express Gateway [user](http://www.express-gateway.io/docs/consumer-management#users).
 
 Users and [applications](http://www.express-gateway.io/docs/consumer-management#applications) have a one-to-many relationship, so you must create a user before you create an application.

--- a/docs/configuration/gateway.config.yml/apiEndpoints.md
+++ b/docs/configuration/gateway.config.yml/apiEndpoints.md
@@ -83,8 +83,7 @@ paths: /admin
 ```
 
 - match: /admin only
-- 404:
-- /admin/bob; /admin/charlie/1; /staff
+- 404: /admin/bob; /admin/charlie/1; /staff
 
 ---
 


### PR DESCRIPTION
Came across these two typos while reading docs.
1. There is no endpoint at port 3000, should be 8080.
2. Misplaced new line changes the meaning.