### PR TITLE
Uncomment page title for plugins page

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -1,6 +1,6 @@
 ---
 layout: doc-section
-<!--title:  "Plugins"-->
+title:  "Plugins"
 doc-order: 25.0
 ---
 


### PR DESCRIPTION
This PR will uncomment the page title, allowing jekyll to correctly show and index it