### PR TITLE
docs: fix use of user id in rate-limit docs

### DIFF
--- a/docs/policies/rate-limiter.md
+++ b/docs/policies/rate-limiter.md
@@ -92,10 +92,10 @@ pipeline1:
       - key-auth:   # force key-auth for all requests in this pipeliene
       - rate-limit:
         -
-          action:              # allow
-            max: 10            # max 10 request 
-            windowMs: 120000   # per 120 seconds
-            rateLimitBy: "${user.id}" # EgContext.user.id 
+          action:                         # allow
+            max: 10                       # max 10 request 
+            windowMs: 120000              # per 120 seconds
+            rateLimitBy: "${req.user.id}" # EgContext.req.user.id 
       - proxy:
         -
           action:


### PR DESCRIPTION
`user.id` doesn't seem to work in `rateLimitBy`, but `req.user.id` does. Not sure if that's a bug or intentional but figured one of those should be fixed