### PR TITLE
Put hierarchy informations in the page

### DIFF
--- a/_layouts/doc-section.html
+++ b/_layouts/doc-section.html
@@ -1,5 +1,24 @@
 {% include head.html %}
 
+{% assign pageurl_array = page.url | split: "/" %}
+{% assign base = pageurl_array[0] %}
+{% assign path = pageurl_array[1] %}
+{% assign section = pageurl_array[2] %}
+{% assign subsection = pageurl_array[3] %}
+{% assign subsubsection = pageurl_array[4] %}
+
+{% if subsubsection %}
+  {% capture parent_url %}{{base}}/{{ path }}/{{ section }}/{{ subsection }}/{% endcapture %}
+  {% capture parent_parent_url %}{{base}}/{{ path }}/{{ section }}/{% endcapture %}
+  {% capture parent_parent_parent_url %}{{base}}/{{ path }}/{% endcapture %}
+{% elsif subsection %}
+  {% capture parent_parent_url %}{{base}}/{{ path }}/{{ section }}/{% endcapture %}
+  {% capture parent_parent_parent_url %}{{base}}/{{ path }}/{% endcapture %}
+{% else %}
+  {% capture parent_parent_parent_url %}{{base}}/{{ path }}/{% endcapture %}
+{% endif %}
+
+
 <body class="sticky">
   {% include header.html %}
   <div class="container page documentation sticky-flex {{ page.class }}">
@@ -9,7 +28,18 @@
       </aside>
       <main class="markdown" id="markdown">
         <section class="doc-wrapper">
-         <h2>{{ page.title }}</h2>
+          {% for cycledPage in site.pages %}
+            {% if cycledPage.url == parent_parent_parent_url %}
+              <p class="lv0">{{ cycledPage.title }}</p>
+            {% endif %}
+            {% if cycledPage.url == parent_parent_url %}
+              <p class="lv1">{{ cycledPage.title }}</p>
+            {% endif %}
+            {% if cycledPage.url == parent_url %}
+              <p class="lv2">{{ cycledPage.title }}</p>
+            {% endif %}
+          {% endfor %}
+         <h1>{{ page.title }}</h1>
           {{ content }}
         </section>
       </main>

--- a/_layouts/doc-section.html
+++ b/_layouts/doc-section.html
@@ -30,13 +30,13 @@
         <section class="doc-wrapper">
           {% for cycledPage in site.pages %}
             {% if cycledPage.url == parent_parent_parent_url %}
-              <p class="lv0">{{ cycledPage.title }}</p>
+              <p class="algoliaLv0">{{ cycledPage.title }}</p>
             {% endif %}
             {% if cycledPage.url == parent_parent_url %}
-              <p class="lv1">{{ cycledPage.title }}</p>
+              <p class="algoliaLv1">{{ cycledPage.title }}</p>
             {% endif %}
             {% if cycledPage.url == parent_url %}
-              <p class="lv2">{{ cycledPage.title }}</p>
+              <p class="algoliaLv2">{{ cycledPage.title }}</p>
             {% endif %}
           {% endfor %}
          <h1>{{ page.title }}</h1>

--- a/_layouts/doc-section.html
+++ b/_layouts/doc-section.html
@@ -9,7 +9,7 @@
       </aside>
       <main class="markdown" id="markdown">
         <section class="doc-wrapper">
-         <h1>{{ page.title }}</h1>
+         <h2>{{ page.title }}</h2>
           {{ content }}
         </section>
       </main>

--- a/_sass/_documentation.scss
+++ b/_sass/_documentation.scss
@@ -20,7 +20,6 @@
     font-family: 'Inconsolata', monospace;
   }
 
-
   .wrapper {
     display: flex;
     flex-direction: row;
@@ -329,7 +328,13 @@
       }
     }
   }
+
+  .algoliaLv0, .algoliaLv1, .algoliaLv2 {
+    display: none;
+  }
 }
+
+
 
 main.markdown > .doc-wrapper > table {
   width: 100%;


### PR DESCRIPTION
This PR will insert some hidden elements that'll be used by Algolia to understand the page hierarchy.

This should hopefully give us a better search experience.

## Warn

I know this is probably not the best way to implement such thing, but before nitpick it and make it code-perfect I want to make sure Algolia's crawler can effectively leverage these new infos.

Connect #160 