### PR TITLE
fix(docs): Activate/Deactivate Credential api url change

### DIFF
--- a/docs/admin/credentials/index.md
+++ b/docs/admin/credentials/index.md
@@ -130,7 +130,7 @@ Any API Consumer (Users/Apps) can have only one credential of type `basic-auth` 
 ```
 
 ### Activate/Deactivate Credential
-##### Request: `PUT /credential/{type}/{credentialId}/status`
+##### Request: `PUT /credentials/{type}/{credentialId}/status`
 ```json
 {
   "status": true  // use false to deactivate


### PR DESCRIPTION
Activate/Deactivate Credential had api url as
PUT /credential/{type}/{credentialId}/status
which should've been credentials