### PR TITLE
docs: fix link in getting started page

### DIFF
--- a/_pages/getting-started.md
+++ b/_pages/getting-started.md
@@ -217,5 +217,5 @@ Note: Express Gateway comes with an in-memory database.  All config file changes
 </section>
 </article>
 
-[pipeline]: {{ site.baseurl }}{% link docs/policies/index.md %}
-[policies]: {{ site.baseurl }}{% link docs/core-concepts.md %}#pipelines
+[policies]: {{ site.baseurl }}{% link docs/policies/index.md %}
+[pipeline]: {{ site.baseurl }}{% link docs/core-concepts.md %}#pipelines


### PR DESCRIPTION
In the `Getting started page`, `policies` and `pipeline` had interchanged links