### PR TITLE
docs: fix lambda-proxy name in example

### DIFF
--- a/docs/policies/lambda.md
+++ b/docs/policies/lambda.md
@@ -19,28 +19,29 @@ Then add `lambda` in [gateway.config.yml][gateway.config.yml] in the [policies][
 ```yaml
 
 policies:
-  - lambda
+  - lambda-proxy
 ```
 
 ### Example
 
 ```yaml
 
-policies:
-  -
-    lambda:
-      -
-        condition:
-          name: pathExact
-          match: /foo/bar # Express Path
-        action:
-          functionName: process-list
-      -
-        condition:
-          name: regexpmatch
-          match: ^/js/(.*)$
-        action:
-          functionName: send-file
+pipelines:
+  default:
+    policies:
+      - lambda-proxy:
+          -
+            condition:
+              name: pathExact
+              match: /foo/bar # Express Path
+            action:
+              functionName: process-list
+          -
+            condition:
+              name: regexpmatch
+              match: ^/js/(.*)$
+            action:
+              functionName: send-file
 ```
 
 ### Reference


### PR DESCRIPTION
In the the examples, earlier, by mistake I used `lambda` instead of `lambda-proxy` in `policy` section of config. Fixed that now.