### PR TITLE
fix: Open Graph meta tags in head for posts

### DIFF
--- a/_includes/insert-to-head.html
+++ b/_includes/insert-to-head.html
@@ -25,11 +25,26 @@ src="https://www.facebook.com/tr?id=1414006978680368&ev=PageView&noscript=1"
 <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/3963534.js"></script>
 <!-- End of HubSpot Embed Code -->
 <!-- Open Graph data -->
-<meta property="og:title" content="Get Involved with Express Gateway"/>
+{% if page.title %}
+    <meta property="og:title" content="{{ page.title }}" />
+{% else %}
+    <meta property="og:title" content="Get Involved with Express Gateway"/>
+{% endif %}
+
 <meta property="og:url" content="https://www.express-gateway.io"/>
 <meta property="og:type" content="website"/>
-<meta property="og:description" content="Express Gateway, an open source API Gateway for Microservices built entirely on ExpressJS and Node.js. Learn more about how to put it to work."/>
-<meta property="og:image" content="{{ site.baseurl }}/assets/img/ExpressGateway_metaimage.png"/>
+
+{% if page.subtitle %}
+    <meta property="og:description" content="{{ page.subtitle }}" />
+{% else %}
+    <meta property="og:description" content="Express Gateway, an open source API Gateway for Microservices built entirely on ExpressJS and Node.js. Learn more about how to put it to work."/>
+{% endif %}
+
+{% if page.header-img %}
+    <meta property="og:image" content="{{ site.url }}/{{ page.header-img }}" />
+{% else %}
+    <meta property="og:image" content="{{ site.baseurl }}/assets/img/ExpressGateway_metaimage.png"/>
+{% endif %}
 <!-- End Open Graph data -->
 <!-- Meta Tags -->
 <meta name="description" content="Express Gateway, an open source API Gateway for Microservices built entirely on ExpressJS. Learn more about how to put it to work."/>


### PR DESCRIPTION
- currently, link preview on Fb, Linkedin for shared posts are incorrect
- these meta tags provide information about posts for correct link preview

### Incorrect Link preview, see below
![Peek 2019-04-01 03-27](https://user-images.githubusercontent.com/13567359/55295725-1b9ccb00-542e-11e9-85f8-aac9a105c928.gif)
