### PR TITLE
Add namespace key to in memory config example

### DIFF
--- a/docs/configuration/system.config.yml/db.md
+++ b/docs/configuration/system.config.yml/db.md
@@ -23,6 +23,7 @@ Two ways possible for now: In Memory and Redis.
 db:
   redis:
     emulate: true
+    namespace: EG
 ```
 
 ### Redis database:


### PR DESCRIPTION
Without the `namespace` key, the server simply crash in the following way :
```
express-gateway_1  | /usr/local/share/.config/yarn/global/node_modules/express-gateway/lib/services/credentials/credential.dao.js:6
express-gateway_1  | const scopeDbKey = config.systemConfig.db.redis.namespace.concat('-', scopeNamespace);
express-gateway_1  |                                                           ^
express-gateway_1  | 
express-gateway_1  | TypeError: Cannot read property 'concat' of undefined
express-gateway_1  |     at Object.<anonymous> (/usr/local/share/.config/yarn/global/node_modules/express-gateway/lib/services/credentials/credential.dao.js:6:59)
express-gateway_1  |     at Module._compile (internal/modules/cjs/loader.js:776:30)
express-gateway_1  |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
express-gateway_1  |     at Module.load (internal/modules/cjs/loader.js:653:32)
express-gateway_1  |     at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
express-gateway_1  |     at Function.Module._load (internal/modules/cjs/loader.js:585:3)
express-gateway_1  |     at Module.require (internal/modules/cjs/loader.js:690:17)
express-gateway_1  |     at require (internal/modules/cjs/helpers.js:25:18)
express-gateway_1  |     at Object.<anonymous> (/usr/local/share/.config/yarn/global/node_modules/express-gateway/lib/services/credentials/credential.service.js:8:23)
express-gateway_1  |     at Module._compile (internal/modules/cjs/loader.js:776:30)
```

Adding `namespace: EG` fixes the problem.