### PR TITLE
Change hostname to host in admin conf example

### DIFF
--- a/docs/configuration/gateway.config.yml/admin.md
+++ b/docs/configuration/gateway.config.yml/admin.md
@@ -7,14 +7,14 @@ list-order: 0.3
 
 ### Description
 
-The admin section is a internal endpoint for the Admin REST API. Express Gateway will listen on the specified hostname and port for internal API requests.
+The admin section is a internal endpoint for the Admin REST API. Express Gateway will listen on the specified host and port for internal API requests.
 
 ### Usage:
 
 ```yaml
 
 admin:
-    hostname: localhost
+    host: localhost
     port: 9080            # EG will listen for http requests on port 9080
 
 ```
@@ -23,5 +23,5 @@ admin:
 
 | Name   | Description                        |
 |---     |---                                 |
-| `hostname` | the hostname to accept requests on |
+| `host` | the hostname to accept requests on |
 | `port` | the port to listen on              |


### PR DESCRIPTION
When using the example configuration, express-gateway will warn about deprecated `hostname` key and tell us to use `host` instead.

```
express-gateway_1  | 2019-07-09T21:50:03.470Z [EG:admin] warn: Warning! use of hostname is deprecated in admin section, use host instead
```