### PR TITLE
Renamed "host" to "hostname" ("usage" zone).

### DIFF
--- a/docs/configuration/gateway.config.yml/http.md
+++ b/docs/configuration/gateway.config.yml/http.md
@@ -15,7 +15,7 @@ The http section is used to configure HTTP. Express Gateway will listen on  the 
 
 http:
     port: 9080            # EG will listen for http requests on port 9080
-    host: localhost
+    hostname: localhost
 ```
 
 ### Options:


### PR DESCRIPTION
We need to rename the "host" attribute to "hostname" (it's the real name used by "express-gateway/lib/gateway/index.js" file, line 23):

const runningApp = server.listen(serverConfig.port, serverConfig.**hostname,** () => {