### PR TITLE
Correct Proxy Timeout Parameter Name

### DIFF
--- a/docs/policies/proxy.md
+++ b/docs/policies/proxy.md
@@ -104,7 +104,7 @@ pipelines:
       ```
 * `headers`:
   - object with extra headers to be added to target requests.
-* `proxyTimeout`:
+* `timeout`:
   - timeout (in millis) when proxy receives no response from target
 
 #### Load balancing strategies


### PR DESCRIPTION
The Proxy rule parameter that controls timeout is incorrectly labeled `proxyTimeout` but should be labelled `timeout`.