### PR TITLE
docs/core-concepts: fix grammatical typo

### DIFF
--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -25,7 +25,7 @@ Endpoints are URLs. Express Gateway has two different types of endpoints:
 * API endpoints
 * Service endpoints
 
-Express Gateway expose APIs through API endpoints. As a gateway, it proxies API requests from API endpoints to microservices referenced in service endpoints.
+Express Gateway exposes APIs through API endpoints. As a gateway, it proxies API requests from API endpoints to microservices referenced in service endpoints.
 
 ### policies
 A policy is a set of conditions, action and parameters that are evaluated and act on the API request and response flow within Express Gateway. Policies within Express Gateway utilize [Express middleware](https://expressjs.com/en/guide/using-middleware.html).


### PR DESCRIPTION
In `docs/core-concepts.md`, under endpoints, the docs say "Express Gateway expose APIs through API endpoints," Grammatically, this should be changed to "Express Gateway __exposes__ APIs through API endpoints."